### PR TITLE
feat(swagger): Support x-doc-exclude and x-doc-host

### DIFF
--- a/lib/nodejs/swagger-store.js
+++ b/lib/nodejs/swagger-store.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const {Swagger, docExclude} = require('./swagger');
+const {Swagger, decorators } = require('./swagger');
 const crypto = require('crypto');
 const path = require('path');
 const store = Object.create(null);
@@ -76,7 +76,8 @@ module.exports = ({hexo}) => {
 
     return swagger
       .validate()
-      .then(swagger =>  swagger.decorate(docExclude))
+      .then(swagger =>  swagger.decorate(decorators.docExclude))
+      .then(swagger =>  swagger.decorate(decorators.host))
       .then(swagger => {
         return handleRoute(swagger, swaggerPath);
       })
@@ -99,7 +100,7 @@ module.exports = ({hexo}) => {
   };
 
 
-  const getRoute = function (swaggerPath){
+  const getRoutes = function (swaggerPath){
     let routes = null;
 
     if (swaggerPath){
@@ -114,7 +115,7 @@ module.exports = ({hexo}) => {
 
   return {
     getSwagger,
-    getRoute,
+    getRoutes,
     setRoute,
     getDigest,
     prepareRoute

--- a/lib/nodejs/swagger-store.js
+++ b/lib/nodejs/swagger-store.js
@@ -1,0 +1,123 @@
+'use strict';
+
+const {Swagger, docExclude} = require('./swagger');
+const crypto = require('crypto');
+const path = require('path');
+const store = Object.create(null);
+const digestStore = Object.create(null);
+const routeMap = Object.create(null);
+const validUrl = require('valid-url');
+
+
+module.exports = ({hexo}) => {
+
+  const getDigest = (swaggerPath) => {
+    // Check filepath or http path
+    if (digestStore[swaggerPath]){
+      return digestStore[swaggerPath];
+    }
+    const digest = crypto.createHash('md5').update(swaggerPath).digest('hex');
+    digestStore[swaggerPath] = digest;
+    return digest;
+  };
+
+
+  const prepareRoute = function (specPath){
+    const digest = getDigest(specPath);
+    const basename = path.basename(specPath);
+    const downloadRoute = digest + '/' + basename;
+    return downloadRoute;
+  };
+
+
+  const handleRoute = (swagger, swaggerPath) => {
+    const jsonSchema = swagger.swaggerJson;
+    const yamlSchema = swagger.swaggerYaml;
+    const extname = path.extname(swaggerPath);
+    const downloadRoute = prepareRoute(swaggerPath);
+
+    if (extname === '.json'){
+      setRoute(downloadRoute, jsonSchema);
+      setRoute(downloadRoute.replace(/\.json$/, '.yaml'), yamlSchema);
+    } else {
+      setRoute(downloadRoute, yamlSchema);
+      setRoute(downloadRoute.replace(/\.yaml$/, '.json'), jsonSchema);
+    }
+
+    /**
+     * Hexo converts all the yaml file to json file.
+     * removeLocalYamlRoute updates routeMap to remove that route.
+     */
+    if (!validUrl.isUri(swaggerPath)){
+      removeLocalYamlRoute(swaggerPath);
+    }
+    return Promise.resolve(downloadRoute);
+  };
+
+
+  const removeLocalYamlRoute = (swaggerPath) => {
+    const sourceDir = hexo.source_dir;
+    const relativePath = swaggerPath
+      .replace(sourceDir, '')
+      .replace(/\.yaml$/, '.json')
+      .replace(/\.yml$/, '.json');
+    setRoute(relativePath, null);
+  };
+
+
+  const getSwagger = function (swaggerPath){
+    const digest = getDigest(swaggerPath);
+
+    if (store[digest]){
+      return Promise.resolve(store[digest]);
+    }
+
+    const swagger = new Swagger(swaggerPath);
+
+    return swagger
+      .validate()
+      .then(swagger =>  swagger.decorate(docExclude))
+      .then(swagger => {
+        return handleRoute(swagger, swaggerPath);
+      })
+      .then(downloadRoute => {
+        const result = {
+          swagger,
+          downloadRoute
+        };
+        store[digest] = result;
+        return result;
+      });
+  };
+
+
+  const setRoute = function (path, data){
+    if (!path){
+      return;
+    }
+    routeMap[path] = data;
+  };
+
+
+  const getRoute = function (swaggerPath){
+    let routes = null;
+
+    if (swaggerPath){
+      const digest = getDigest(swaggerPath);
+      routes = routeMap[digest];
+    } else {
+      routes = routeMap;
+    }
+    return routes;
+  };
+
+
+  return {
+    getSwagger,
+    getRoute,
+    setRoute,
+    getDigest,
+    prepareRoute
+  };
+
+};

--- a/lib/nodejs/swagger-to-html/__tests__/index.test.js
+++ b/lib/nodejs/swagger-to-html/__tests__/index.test.js
@@ -1,29 +1,33 @@
 'use strict';
 
-const path = require('path');
-
-// NOTE: consolidate autoload "installed template engines",
-// but it doesn't work while running test suites with jest,
-// so we should load them manually
-const consolidate = require('consolidate');
-consolidate.requires.ejs = require('ejs');
-
 describe('swagger-to-html', () => {
-  const swaggerToHTML = require('../index');
 
-  it('shouldn\'t emit any error', (done) => {
-    const data = [];
-    swaggerToHTML(path.resolve(__dirname, './_petstore.yaml'))
-      .on('error', (err) => {
-        expect(err).toBeUndefined();
-        done(err);
-      })
-      .on('data', (chunk) => {
-        data.push(chunk);
-      }) // the stream will never fire "end" event if nobody is consuming it, that's why we consume it
-      .on('end', () => {
-        expect(data.length > 0).toBe(true);
-        done();
+  const mockGetSwagger = jest.fn()
+    .mockImplementationOnce(() => {
+      return Promise.resolve({
+        swagger: {
+          swaggerObject: 'SWAGGER_OBJECT'
+        }
       });
+    });
+
+  jest.mock('../../swagger-store', () => {
+    return () => ({
+      getSwagger: mockGetSwagger
+    });
+  });
+
+  jest.mock('../core', () => {
+    return {
+      createTransformer: ({input}) => {
+        return input();
+      }
+    };
+  });
+  const hexo = {};
+  const transformerPromise = require('../index')({hexo});
+
+  it('shouldn\'t emit any error', async () => {
+    await expect(transformerPromise).resolves.toEqual('SWAGGER_OBJECT');
   });
 });

--- a/lib/nodejs/swagger-to-html/helpers/parser/lib/traverse.js
+++ b/lib/nodejs/swagger-to-html/helpers/parser/lib/traverse.js
@@ -5,6 +5,9 @@ let result;
 
 function traverse ({object, key, isRequired, init}){
 
+  if (!object){
+    return {};
+  }
   // handle allOf property
   if (object.allOf){
     let mergedObj = {type: 'object'};

--- a/lib/nodejs/swagger-to-html/index.js
+++ b/lib/nodejs/swagger-to-html/index.js
@@ -1,10 +1,16 @@
 'use strict';
 
 const modules = require('./modules');
-const SwaggerParser = require('swagger-parser');
 const {createTransformer} = require('./core');
 
-module.exports = createTransformer({
-  input: api => SwaggerParser.validate(api),
+module.exports = ({hexo}) => createTransformer({
+  input: (api) => {
+    const swaggerStore = require('../swagger-store')({hexo});
+    return swaggerStore
+      .getSwagger(api)
+      .then(({swagger}) => {
+        return Promise.resolve(swagger.swaggerObject);
+      });
+  },
   modules
 });

--- a/lib/nodejs/swagger-to-html/modules/controllers/__tests__/requestSample.test.js
+++ b/lib/nodejs/swagger-to-html/modules/controllers/__tests__/requestSample.test.js
@@ -104,7 +104,7 @@ describe('controllers.requestSample', () => {
       'baseUrl': 'https://example.com/'
     } ;
 
-    let curlStr = 'curl -v -x GET https://example.com/some/path/ThisIsMerchantId/ThisIsAnOrderId?include=ThisIsInclude  \\\n-H "Authorization: Bearer <Access-Token>"  \\\n-H "X-Flow-Id: ThisIsXFLOWID"  \\\n-F "file: ThisIsInclude"  \\\n-F "document-type: ThisIsInclude"  \\\n';
+    let curlStr = 'curl -v GET https://example.com/some/path/ThisIsMerchantId/ThisIsAnOrderId?include=ThisIsInclude  \\\n-H "Authorization: Bearer <Access-Token>"  \\\n-H "X-Flow-Id: ThisIsXFLOWID"  \\\n-F "file: ThisIsInclude"  \\\n-F "document-type: ThisIsInclude"  \\\n';
 
     curlStr += JSON.stringify(requestBody, null, 2);
 

--- a/lib/nodejs/swagger-to-html/modules/controllers/requestSample.js
+++ b/lib/nodejs/swagger-to-html/modules/controllers/requestSample.js
@@ -53,7 +53,7 @@ const requestSample = (ctx) => {
 
 
   // Create CURL string
-  let curlString = 'curl -v -x ' + verb + ' ' + baseUrl.replace(/\/$/, '') + path + '  \\\n';
+  let curlString = 'curl -v ' + verb + ' ' + baseUrl.replace(/\/$/, '') + path + '  \\\n';
 
   Object.keys(sample.header).forEach((header) => {
     if ('Authorization' === header){

--- a/lib/nodejs/swagger-ui/__tests__/parse-schema-file.test.js
+++ b/lib/nodejs/swagger-ui/__tests__/parse-schema-file.test.js
@@ -1,45 +1,30 @@
 'use strict';
 
-const {mockFileContent} = require('./mocks');
 const ParseSchemaFileError = require('../parse-schema-file-error.js');
-
-/**
- * Mocking implementation, so that for first two calls it responds with content and in third call it will throw an error.
- */
-const mockReadFileSync = jest.fn()
-  .mockImplementationOnce( path => mockFileContent[path] )
-  .mockImplementationOnce( path => mockFileContent[path] )
-  .mockImplementationOnce( path  => {
-    throw new ParseSchemaFileError({
-      'message': 'File read error',
-      'filePath': path,
-      'referencePath': 'pageSource'
-    });
-  });
-
-/**
- * Mocking implementation, so that first and third call will be resolved and second call will rejected.
- */
-
-const mockValidate = jest.fn()
-  .mockImplementationOnce( ()  => Promise.resolve())
-  .mockImplementationOnce( path  => Promise.reject(new ParseSchemaFileError({
-    'message': 'Swagger Parse Error',
-    'filePath': path,
-    'referencePath': 'pageSource'
-  }))
-  )
-  .mockImplementationOnce(()  => Promise.resolve());
 
 describe('parse-schema-file', () => {
 
-  jest.mock('fs', () => ({
-    readFileSync: mockReadFileSync
-  }));
+  const mockGetSwagger = jest.fn()
+    .mockImplementationOnce(() => {
+      return Promise.resolve({
+        swagger: {
+          swaggerJson: 'SWAGGER'
+        }
+      });
+    })
+    .mockImplementationOnce(() => {
+      return Promise.reject(new ParseSchemaFileError({
+        'message': 'There is an error reading the file.',
+        'filePath': '/path/to/swagger/petstore.json',
+        'referencePath': 'path/to/md/file'
+      }));
+    });
 
-  jest.mock('swagger-parser', () => ({
-    validate: mockValidate
-  }));
+  jest.mock('../../swagger-store', () => {
+    return () => ({
+      getSwagger: mockGetSwagger
+    });
+  });
 
   const parseSchemaFile = require('../parse-schema-file');
 
@@ -48,15 +33,11 @@ describe('parse-schema-file', () => {
     const mdFilePath = 'path/to/md/file';
     const expectedOutput = {
       'pageSource': mdFilePath,
-      'swagger': mockFileContent[swaggerFilePath]
+      'swagger': 'SWAGGER'
     };
-    await expect(parseSchemaFile(swaggerFilePath, mdFilePath)).resolves.toEqual(expectedOutput);
-  });
-
-  test('should catch swagger parsing error when swagger file contains invalid schema', async () => {
-    const swaggerFilePath = '/path/to/swagger/error.json';
-    const mdFilePath = 'path/to/md/file';
-    await expect(parseSchemaFile(swaggerFilePath, mdFilePath)).rejects.toBeInstanceOf(ParseSchemaFileError);
+    const hexo = {};
+    await expect(parseSchemaFile(swaggerFilePath, mdFilePath, hexo)).resolves.toEqual(expectedOutput);
+    expect(mockGetSwagger).toBeCalled();
   });
 
   test('should catch file read error for file read issues', async () => {

--- a/lib/nodejs/swagger-ui/index.js
+++ b/lib/nodejs/swagger-ui/index.js
@@ -5,6 +5,7 @@ const path = require('path');
 const touch = require('touch');
 const parseSchemaFile = require('./parse-schema-file.js');
 const hexoUtil = require('../hexo-util');
+const validUrl = require('valid-url');
 
 const DEFAULT_CONFIG = {
   api_explorer: true,
@@ -96,7 +97,11 @@ const createSwaggerUI = function ({hexo}) {
   function swaggerUITag (args){
     const ctx = this;
     const pageSource = ctx.source;
-    const swaggerPath = path.resolve(path.dirname(ctx.full_source), args[0]);
+    let swaggerPath = args[0];
+
+    if (!validUrl.isUri(swaggerPath)){
+      swaggerPath = path.resolve(path.dirname(ctx.full_source), swaggerPath);
+    }
 
 
     /**
@@ -107,7 +112,7 @@ const createSwaggerUI = function ({hexo}) {
     }
     specBacklinks[swaggerPath].add(ctx.full_source);
 
-    return parseSchemaFile(swaggerPath, pageSource)
+    return parseSchemaFile(swaggerPath, pageSource, hexo)
       .then(uiGenerator.getHtml)
       .catch(error => {
         log.error('----------------------------------------------------------------');

--- a/lib/nodejs/swagger-ui/parse-schema-file.js
+++ b/lib/nodejs/swagger-ui/parse-schema-file.js
@@ -1,36 +1,23 @@
 'use strict';
 
-const fs = require('fs');
-const path = require('path');
-const validator = require('swagger-parser');
-const yaml = require('js-yaml');
 const ParseSchemaFileError = require('./parse-schema-file-error.js');
 
+function parseSchemaFile (filePath, pageSource, hexo) {
 
-function parseSchemaFile (filepath, pageSource) {
+  const swaggerStore = require('../swagger-store')({hexo});
   try {
-    const specFileContent = fs.readFileSync(filepath,'utf8');
-    const ext = path.extname(filepath);
-    return validator
-      .validate(filepath)
-      .then(() => {
-        const swaggerObj = ext === 'json' ? JSON.parse(specFileContent) : yaml.safeLoad(specFileContent);
+    return swaggerStore
+      .getSwagger(filePath)
+      .then(({swagger}) => {
         return {
           pageSource: pageSource,
-          swagger: JSON.stringify(swaggerObj)
+          swagger: swagger.swaggerJson
         };
-      })
-      .catch(() => {
-        return Promise.reject(new ParseSchemaFileError({
-          'message': 'There is an error parsing the swagger file.',
-          'filePath': filepath,
-          'referencePath': pageSource
-        }));
       });
   } catch (error){
-    return Promise.reject( new ParseSchemaFileError({
+    return Promise.reject(new ParseSchemaFileError({
       'message': 'There is an error reading the file.',
-      'filePath': filepath,
+      'filePath': filePath,
       'referencePath': pageSource
     }));
   }

--- a/lib/nodejs/swagger/decorators/docExclude/filters/index.js
+++ b/lib/nodejs/swagger/decorators/docExclude/filters/index.js
@@ -1,0 +1,14 @@
+'use strict';
+
+const filterOperations = require('./operations');
+const filterParameters = require('./parameters');
+const filterPaths = require('./paths');
+const filterSecurity = require('./security');
+
+
+module.exports = {
+  filterOperations,
+  filterParameters,
+  filterPaths,
+  filterSecurity
+};

--- a/lib/nodejs/swagger/decorators/docExclude/filters/operations.js
+++ b/lib/nodejs/swagger/decorators/docExclude/filters/operations.js
@@ -1,0 +1,26 @@
+'use strict';
+
+const { isExclude } = require('../utils');
+
+
+const filterOperations = (swagger) => {
+
+  swagger.paths && Object
+    .keys(swagger.paths)
+    .forEach((key) => {
+      const path = swagger.paths[key] ;
+      path && Object
+        .keys(path)
+        .forEach((verb) => {
+          const operation = path[verb];
+          if (isExclude(operation)){
+            delete path[verb];
+          }
+        });
+    });
+
+  return swagger;
+};
+
+
+module.exports = filterOperations;

--- a/lib/nodejs/swagger/decorators/docExclude/filters/parameters.js
+++ b/lib/nodejs/swagger/decorators/docExclude/filters/parameters.js
@@ -1,0 +1,54 @@
+'use strict';
+
+const { isExclude } = require('../utils');
+const { filter } = require('lodash');
+
+
+/**
+ * Filter parameters.
+ */
+const filterParameters = (swagger) => {
+
+  const paramsToRemove = [];
+
+  let parameters = swagger.parameters;
+  parameters = parameters && Object
+    .keys(parameters)
+    .forEach((key) => {
+      const value = parameters[key];
+      if (isExclude(value)){
+        delete parameters[key];
+        paramsToRemove.push(key);
+      }
+    });
+
+
+  /**
+   * Filter params for operations
+   * */
+  if (paramsToRemove.length){
+    swagger.paths && Object
+      .keys(swagger.paths)
+      .forEach((key) => {
+        const path = swagger.paths[key];
+        path && Object
+          .keys(path)
+          .forEach((verb) => {
+            const operation = path[verb];
+            if ('object' !== typeof operation){
+              return;
+            }
+
+            const parameters = operation.parameters;
+            if (Array.isArray(parameters)){
+              operation.parameters = filter(parameters, parameter => !isExclude(parameter));
+            }
+          });
+      });
+  }
+
+  return swagger;
+};
+
+
+module.exports = filterParameters;

--- a/lib/nodejs/swagger/decorators/docExclude/filters/parameters.js
+++ b/lib/nodejs/swagger/decorators/docExclude/filters/parameters.js
@@ -10,15 +10,14 @@ const { filter } = require('lodash');
 const filterParameters = (swagger) => {
 
   const paramsToRemove = [];
-
-  let parameters = swagger.parameters;
-  parameters = parameters && Object
-    .keys(parameters)
+  // Filter swager parameter definitions
+  swagger.parameters && Object
+    .keys(swagger.parameters)
     .forEach((key) => {
-      const value = parameters[key];
+      const value = swagger.parameters[key];
       if (isExclude(value)){
-        delete parameters[key];
-        paramsToRemove.push(key);
+        paramsToRemove.push(value.name);
+        delete swagger.parameters[key];
       }
     });
 
@@ -26,26 +25,24 @@ const filterParameters = (swagger) => {
   /**
    * Filter params for operations
    * */
-  if (paramsToRemove.length){
-    swagger.paths && Object
-      .keys(swagger.paths)
-      .forEach((key) => {
-        const path = swagger.paths[key];
-        path && Object
-          .keys(path)
-          .forEach((verb) => {
-            const operation = path[verb];
-            if ('object' !== typeof operation){
-              return;
-            }
+  swagger.paths && Object
+    .keys(swagger.paths)
+    .forEach((key) => {
+      const path = swagger.paths[key];
+      path && Object
+        .keys(path)
+        .forEach((verb) => {
+          const operation = path[verb];
+          if ('object' !== typeof operation){
+            return;
+          }
 
-            const parameters = operation.parameters;
-            if (Array.isArray(parameters)){
-              operation.parameters = filter(parameters, parameter => !isExclude(parameter));
-            }
-          });
-      });
-  }
+          const parameters = operation.parameters;
+          if (Array.isArray(parameters)){
+            operation.parameters = filter(parameters, parameter => !paramsToRemove.includes(parameter.name) && !isExclude(parameter));
+          }
+        });
+    });
 
   return swagger;
 };

--- a/lib/nodejs/swagger/decorators/docExclude/filters/paths.js
+++ b/lib/nodejs/swagger/decorators/docExclude/filters/paths.js
@@ -1,0 +1,21 @@
+'use strict';
+
+const { isExclude } = require('../utils');
+
+
+const filterPaths = (swagger) => {
+
+  swagger.paths && Object
+    .keys(swagger.paths)
+    .forEach((key) => {
+      const path = swagger.paths[key];
+      if (isExclude(path)){
+        delete swagger.paths[key];
+      }
+    });
+
+  return swagger;
+};
+
+
+module.exports = filterPaths;

--- a/lib/nodejs/swagger/decorators/docExclude/filters/security.js
+++ b/lib/nodejs/swagger/decorators/docExclude/filters/security.js
@@ -1,0 +1,64 @@
+'use strict';
+
+const { isExclude } = require('../utils');
+
+
+/**
+ * Filteres securitDefinitions and security requirements.
+ */
+const filterSecurity = (swagger) => {
+
+  const securityToRemove = [];
+
+  const securityDefinitions = swagger.securityDefinitions;
+
+  const filterSecurityRequirements = (securityArr) => {
+    return securityArr.reduce((acc, curr) => {
+      const key = Object.keys(curr)[0];
+      if (!securityToRemove.includes(key)){
+        acc.push(curr);
+      }
+      return acc;
+    },
+    []);
+  };
+
+  // Remove security definitions
+  securityDefinitions && Object
+    .keys(securityDefinitions)
+    .forEach((key) => {
+      const value = securityDefinitions[key];
+      if (isExclude(value)){
+        securityToRemove.push(key);
+        delete securityDefinitions[key];
+      }
+    });
+
+  // Remove security requirements
+  if (securityToRemove.length){
+
+    // Global security
+    if (swagger.security){
+      swagger.security = filterSecurityRequirements(swagger.security);
+    }
+
+    // Local security
+    swagger.paths && Object
+      .keys(swagger.paths)
+      .forEach((key) => {
+        const path = swagger.paths[key];
+        path && Object
+          .keys(path)
+          .forEach((verb) => {
+            const operation = path[verb];
+            if (operation.security){
+              operation.security = filterSecurityRequirements(operation.security);
+            }
+          });
+      });
+  }
+
+  return swagger;
+};
+
+module.exports = filterSecurity;

--- a/lib/nodejs/swagger/decorators/docExclude/index.js
+++ b/lib/nodejs/swagger/decorators/docExclude/index.js
@@ -1,0 +1,19 @@
+'use strict';
+
+const { filterSecurity, filterParameters, filterPaths, filterOperations} = require('./filters');
+
+const docExclude = (swagger) => {
+
+  swagger = filterSecurity(swagger);
+
+  swagger = filterParameters(swagger);
+
+  swagger = filterPaths(swagger);
+
+  swagger = filterOperations(swagger);
+
+  return  swagger;
+};
+
+
+module.exports = docExclude;

--- a/lib/nodejs/swagger/decorators/docExclude/utils.js
+++ b/lib/nodejs/swagger/decorators/docExclude/utils.js
@@ -1,0 +1,24 @@
+'use strict';
+
+/**
+ * Key for exclude flag.
+ */
+const docKey = 'x-doc';
+const excludeKey = 'exclude';
+
+/**
+ * Function to decide what objects to exclude from the schema.
+ */
+const isExclude = (subject) => {
+  if (subject.hasOwnProperty(docKey)){
+    const isExcludable = !!(subject[docKey] && subject[docKey][excludeKey]);
+    // Delete the key as its not a standard swagger key and will cause issues while rendering in SwaggerUI or Swagger-to-html
+    delete subject[docKey];
+    return isExcludable;
+  }
+  return false;
+};
+
+module.exports = {
+  isExclude
+};

--- a/lib/nodejs/swagger/decorators/host.js
+++ b/lib/nodejs/swagger/decorators/host.js
@@ -1,0 +1,23 @@
+'use strict';
+
+const docKey = 'x-doc';
+const hostKey = 'host';
+
+const host = (swagger) => {
+
+  let host;
+
+  if (swagger && swagger[docKey] && swagger[docKey][hostKey]){
+    host = swagger[docKey][hostKey];
+  }
+  // Add more ways to provide host and order them in priority.
+
+  if (host){
+    swagger.host = host;
+  }
+
+  return swagger;
+};
+
+
+module.exports = host;

--- a/lib/nodejs/swagger/decorators/index.js
+++ b/lib/nodejs/swagger/decorators/index.js
@@ -1,7 +1,9 @@
 'use strict';
 
 const docExclude = require('./docExclude');
+const host = require('./host');
 
 module.exports = {
-  docExclude
+  docExclude,
+  host
 };

--- a/lib/nodejs/swagger/decorators/index.js
+++ b/lib/nodejs/swagger/decorators/index.js
@@ -1,0 +1,7 @@
+'use strict';
+
+const docExclude = require('./docExclude');
+
+module.exports = {
+  docExclude
+};

--- a/lib/nodejs/swagger/index.js
+++ b/lib/nodejs/swagger/index.js
@@ -2,10 +2,10 @@
 
 
 const Swagger = require('./swagger');
-const { docExclude } = require('./decorators');
+const decorators = require('./decorators');
 
 
 module.exports = {
   Swagger,
-  docExclude
+  decorators
 };

--- a/lib/nodejs/swagger/index.js
+++ b/lib/nodejs/swagger/index.js
@@ -1,0 +1,11 @@
+'use strict';
+
+
+const Swagger = require('./swagger');
+const { docExclude } = require('./decorators');
+
+
+module.exports = {
+  Swagger,
+  docExclude
+};

--- a/lib/nodejs/swagger/swagger.js
+++ b/lib/nodejs/swagger/swagger.js
@@ -1,0 +1,184 @@
+'use strict';
+
+const SwaggerParser = require('swagger-parser');
+const Promise = require('bluebird');
+const {merge} = require('lodash');
+const jsYaml = require('js-yaml');
+const isPlainObj = require('is-plain-obj');
+
+class Swagger{
+
+  /**
+   * @param swagger File path for swagger schema or swagger object.
+   *
+   */
+  constructor (swaggerInput){
+    if (!swaggerInput){
+      throw new TypeError('Please provide path for swagger schema or a valid swagger object.');
+    } else {
+      this.swaggerInput = swaggerInput;
+      // Object containing merge of dereferenced swagger and swagger containing references.
+      this.swaggerObject = null;
+    }
+  }
+
+
+  /**
+   * Validates and bundles swagger.
+   *
+   * Merges dereferenced and referenced swagger objects, the merged object will contain $refs and the referenced object.
+   */
+  merge (){
+    const validatePromise = this._validate(this.swaggerInput);
+    const bundlePromise = this._bundle(this.swaggerInput);
+    const promiseArray = [validatePromise, bundlePromise];
+    const that = this;
+
+    // Merging referenced and deferened swagger object to have ref links and the derefrenced object.
+    return Promise.reduce(
+      promiseArray,
+      (aggregate, swagger) => {
+        return merge(aggregate, swagger);
+      },
+      {}
+    )
+      .then((mergedSchema) => {
+        that.swaggerObject = mergedSchema;
+        return Promise.resolve(this);
+      });
+  }
+
+
+  /**
+   * Validates the swagger schema and gives dereferenced swagger object.
+   */
+  validate (){
+    const that = this;
+    return this
+      ._validate(this.swaggerInput)
+      .then((dereferencedSchema) => {
+        that.swaggerObject = dereferencedSchema;
+        return that;
+      });
+  }
+
+
+  /**
+   * Validates the swagger schema and gives dereferenced swagger object.
+   */
+  bundle (){
+    const that = this;
+    return this
+      ._bundle(this.swaggerInput)
+      .then((referencedSchema) => {
+        that.swaggerObject = referencedSchema;
+        return that;
+      });
+  }
+
+
+  /**
+   * Revert the merge of referenced and dereferenced swagger, and use $ref where-ever it is.
+   *
+   * */
+  unmerge (){
+    const refMatchingFunction = (obj) => {
+      if (obj.hasOwnProperty('$ref')){
+        return true;
+      }
+      return false;
+    };
+
+    this.swaggerObject = this._traverseToUnmerge(this.swaggerObject, refMatchingFunction);
+
+    return Promise.resolve(this);
+  }
+
+
+  /**
+   * Decorates swagger object.
+   */
+  decorate (decorator){
+    if ('function' === typeof decorator){
+      this.swaggerObject = decorator(this.swaggerObject);
+    }
+    return Promise.resolve(this);
+  }
+
+
+  /**
+   * Returns yamlSchema string.
+   */
+  get swaggerYaml (){
+    return jsYaml.safeDump(this.swaggerObject);
+  }
+
+
+  /**
+   * Returns jsonSchema string.
+   */
+  get swaggerJson (){
+    return JSON.stringify(this.swaggerObject);
+  }
+
+
+  /**
+   * Internal Methods.
+   */
+
+  /**
+   * Validates the swagger schema and gives dereferenced swagger object.
+   */
+  _validate (schema){
+    return SwaggerParser.validate(schema);
+  }
+
+
+  /**
+   * Bundles and returns referenced swagger object.
+   */
+  _bundle (schema){
+    return SwaggerParser.bundle(schema);
+  }
+
+
+  /**
+   * Travers swagger object and unmerge keys matched to fn.
+   */
+  _traverseToUnmerge (subject, fn){
+    if (isPlainObj(subject)){
+
+      if (fn(subject)){
+        subject = {
+          '$ref': subject['$ref']
+        };
+      }
+
+      subject = Object
+        .keys(subject)
+        .reduce((acc, key) => {
+          if (fn(subject[key])){
+            subject[key] = {
+              '$ref': subject[key]['$ref']
+            };
+          } else {
+            subject[key] = this._traverseToUnmerge(subject[key], fn);
+          }
+          return acc;
+        },
+        subject);
+
+    } else if (Array.isArray(subject)){
+      subject = subject
+        .reduce((acc, key) => {
+          acc.push(this._traverseToUnmerge(key, fn));
+          return acc;
+        },
+        []);
+    }
+
+    return subject;
+  }
+}
+
+module.exports = Swagger;

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "ejs": "^2.5.7",
     "escape-string-regexp": "^1.0.5",
     "hexo-log": "^0.2.0",
+    "is-plain-obj": "^1.1.0",
     "jquery": "^3.2.1",
     "js-crawler": "^0.3.19",
     "js-yaml": "^3.8.4",
@@ -56,7 +57,8 @@
     "striptags": "^3.0.1",
     "swagger-parser": "^4.0.0",
     "touch": "^3.1.0",
-    "url-join": "^2.0.2"
+    "url-join": "^2.0.2",
+    "valid-url": "^1.0.9"
   },
   "devDependencies": {
     "babel-loader": "^7.1.2",

--- a/plugins/swagger-routes.js
+++ b/plugins/swagger-routes.js
@@ -1,13 +1,11 @@
 'use strict';
 
-const util = require('../lib/nodejs/hexo-util');
-
 const getFilter = (hexo) => {
 
   const swaggerStore = require('../lib/nodejs/swagger-store')({hexo});
 
   return () => {
-    const routes = swaggerStore.getRoute();
+    const routes = swaggerStore.getRoutes();
     routes && Object
       .keys(routes)
       .forEach((route) => {
@@ -24,7 +22,6 @@ const getFilter = (hexo) => {
 
 
 module.exports = ({hexo}) => {
-  const {themeConfig} = util({hexo});
   const filter = getFilter(hexo);
   hexo.extend.filter.register('after_generate', filter);
 };

--- a/plugins/swagger-routes.js
+++ b/plugins/swagger-routes.js
@@ -1,0 +1,33 @@
+'use strict';
+
+const util = require('../lib/nodejs/hexo-util');
+
+const getFilter = (hexo) => {
+
+  const swaggerStore = require('../lib/nodejs/swagger-store')({hexo});
+
+  return () => {
+    const routes = swaggerStore.getRoute();
+    routes && Object
+      .keys(routes)
+      .forEach((route) => {
+        const data = routes[route];
+
+        if(data){
+          hexo.route.set(route, data);
+        }else{
+          hexo.route.remove(route);
+        }
+      })
+  }
+}
+
+
+module.exports = ({hexo}) => {
+  const {themeConfig} = util({hexo});
+  const filter = getFilter(hexo);
+  hexo.extend.filter.register('after_generate', filter);
+};
+
+
+

--- a/scripts/all.js
+++ b/scripts/all.js
@@ -9,3 +9,4 @@ require('../plugins/swagger-ui')({hexo});
 require('../plugins/react')({hexo});
 require('../plugins/react-initial-state')({hexo});
 require('../plugins/support')({hexo});
+require('../plugins/swagger-routes')({hexo});


### PR DESCRIPTION
Updates in the PR.
### 1. Add support for parsing swagger file before passing it to `swager-ui` or `swagger-to-html`.
  **Why?**
 There are use cases when you want to process swagger file before using it. Some use cases are removing some paths/operations/definitions that you don't want to expose, updating the host, etc.

Now you can decorate the swagger object before using it.

Some provided decorators : 
#### `x-doc.exclude`
This is decorator is used when you want to remove some definitions/objects from swagger.
You can exclude following definitions.
  * operations: GET, POST, etc. operations for a specific path
  * parameters: Remove parameters that you don't want to expose.
  * paths: Remove complete path from the spec.
  * security: Remove security definitions that are not required for someone who is reading the documentation.

Eg - Some swagger file.
```yaml
swagger: "2.0"
.
.
paths:
  /pets:
    get:
      xdoc:
        exclude: true
.
.
```
The `get` operation from `/pets` will be removed, after the decorator is applied. 

#### `x-doc: host`
```yaml
xdoc:
  host: example.com
```
`xdoc.host` will overwrite the host.

You can add custom decorators in `lib/nodejs/swagger/decorators`

### 2. Support remote links for swagger spec in `swagger-ui` and `swagger-to-html`.
You can pass http links to both the tags.

### 3. Remove `-x` from examples for request in `swagger-to-html`.