### PR TITLE
fix: Add -X to curl examples

### DIFF
--- a/lib/nodejs/swagger-to-html/modules/controllers/__tests__/requestSample.test.js
+++ b/lib/nodejs/swagger-to-html/modules/controllers/__tests__/requestSample.test.js
@@ -104,7 +104,7 @@ describe('controllers.requestSample', () => {
       'baseUrl': 'https://example.com/'
     } ;
 
-    let curlStr = 'curl -v GET https://example.com/some/path/ThisIsMerchantId/ThisIsAnOrderId?include=ThisIsInclude  \\\n-H "Authorization: Bearer <Access-Token>"  \\\n-H "X-Flow-Id: ThisIsXFLOWID"  \\\n-F "file: ThisIsInclude"  \\\n-F "document-type: ThisIsInclude"  \\\n';
+    let curlStr = 'curl -v -X GET https://example.com/some/path/ThisIsMerchantId/ThisIsAnOrderId?include=ThisIsInclude  \\\n-H "Authorization: Bearer <Access-Token>"  \\\n-H "X-Flow-Id: ThisIsXFLOWID"  \\\n-F "file: ThisIsInclude"  \\\n-F "document-type: ThisIsInclude"  \\\n';
 
     curlStr += JSON.stringify(requestBody, null, 2);
 

--- a/lib/nodejs/swagger-to-html/modules/controllers/requestSample.js
+++ b/lib/nodejs/swagger-to-html/modules/controllers/requestSample.js
@@ -53,7 +53,7 @@ const requestSample = (ctx) => {
 
 
   // Create CURL string
-  let curlString = 'curl -v ' + verb + ' ' + baseUrl.replace(/\/$/, '') + path + '  \\\n';
+  let curlString = 'curl -v -X ' + verb + ' ' + baseUrl.replace(/\/$/, '') + path + '  \\\n';
 
   Object.keys(sample.header).forEach((header) => {
     if ('Authorization' === header){


### PR DESCRIPTION

Add `-X` flag to `curl` command for request samples in `swagger-to-html`.