### PR TITLE
fix: Fix issue with yaml parsing of swaggerObject

### DIFF
--- a/lib/nodejs/swagger/__tests__/_petstore-parsed.yaml
+++ b/lib/nodejs/swagger/__tests__/_petstore-parsed.yaml
@@ -1,0 +1,452 @@
+swagger: '2.0'
+info:
+  version: 2.0.0
+  title: Swagger Petstore
+  description: >-
+    A sample API that uses a petstore as an example to demonstrate features in
+    the swagger-2.0 specification
+  termsOfService: 'http://swagger.io/terms/'
+  contact:
+    name: Swagger API Team
+    email: foo@example.com
+    url: 'https://tech.zalando.com'
+  license:
+    name: MIT
+    url: 'http://github.com/gruntjs/grunt/blob/master/LICENSE-MIT'
+securityDefinitions:
+  oauth:
+    type: oauth2
+    tokenUrl: 'https://auth.example.com/oauth2/token'
+    flow: password
+    scopes:
+      petstore.read: Access to read petstore
+      petstore.write: Access to write to petstore
+security:
+  - oauth:
+      - petstore.read
+host: petstore.swagger.io
+basePath: /api
+schemes:
+  - http
+consumes:
+  - application/json
+produces:
+  - application/json
+parameters:
+  Authorization:
+    name: Authorization
+    in: header
+    description: OAUTH2 (IAM) or JWT token
+    required: true
+    type: string
+    format: OAUTH2 (IAM) or JWT token
+paths:
+  /pets:
+    get:
+      summary: Get pets
+      description: |
+        Returns all pets from the system that the user has access to.
+      operationId: findPets
+      parameters:
+        - name: Authorization
+          in: header
+          description: OAUTH2 (IAM) or JWT token
+          required: true
+          type: string
+          format: OAUTH2 (IAM) or JWT token
+        - name: limit
+          in: query
+          description: Maximum number of results to return
+          required: false
+          type: integer
+          format: int32
+          x-example: 10
+      responses:
+        '200':
+          description: Pet response.
+          schema:
+            type: object
+            description: List of pets
+            properties:
+              data:
+                description: List of pets
+                type: array
+                items:
+                  type: object
+                  description: Pet description
+                  properties:
+                    id:
+                      description: Id of pet
+                      type: integer
+                    name:
+                      description: Name of pet
+                      type: string
+                      example: Foo
+                    type:
+                      description: Type of pet
+                      type: string
+                      example: cat
+                    gender:
+                      description: Gender of pet
+                      enum:
+                        - male
+                        - female
+          examples:
+            application/json:
+              data:
+                - id: 1
+                  name: Foo
+                  type: cat
+                  gender: female
+                - id: 2
+                  name: Bar
+                  type: dog
+                  gender: male
+        '403':
+          description: Forbidden
+          schema:
+            required:
+              - code
+              - message
+            type: object
+            properties:
+              code:
+                type: integer
+                format: int32
+                description: Status code
+              message:
+                type: string
+                description: Status message
+        default:
+          description: unexpected error
+          schema:
+            required:
+              - code
+              - message
+            type: object
+            properties:
+              code:
+                type: integer
+                format: int32
+              message:
+                type: string
+    post:
+      summary: Create a pet
+      description: Creates a new pet in the store.  Duplicates are allowed
+      operationId: addPet
+      security:
+        - oauth:
+            - petstore.write
+      parameters:
+        - name: Authorization
+          in: header
+          description: OAUTH2 (IAM) or JWT token
+          required: true
+          type: string
+          format: OAUTH2 (IAM) or JWT token
+        - name: pet
+          in: body
+          description: Pet to add to the store
+          required: true
+          schema:
+            type: object
+            description: Pet description
+            required:
+              - name
+            properties:
+              name:
+                description: Name of pet
+                type: string
+                example: Foo
+              type:
+                description: Type of pet
+                type: string
+                example: cat
+              gender:
+                description: Gender of pet
+                enum:
+                  - male
+                  - female
+          x-examples:
+            default:
+              name: Foo
+              type: cat
+              gender: female
+      responses:
+        '201':
+          description: pet response
+          schema:
+            type: object
+            description: Pet description
+            properties:
+              id:
+                description: Id of pet
+                type: integer
+              name:
+                description: Name of pet
+                type: string
+                example: Foo
+              type:
+                description: Type of pet
+                type: string
+                example: cat
+              gender:
+                description: Gender of pet
+                enum:
+                  - male
+                  - female
+          examples:
+            application/json:
+              id: 1
+              name: Foo
+              type: cat
+              gender: female
+        '403':
+          description: Forbidden
+          schema:
+            required:
+              - code
+              - message
+            type: object
+            properties:
+              code:
+                type: integer
+                format: int32
+                description: Status code
+              message:
+                type: string
+                description: Status message
+        default:
+          description: unexpected error
+          schema:
+            required:
+              - code
+              - message
+            type: object
+            properties:
+              code:
+                type: integer
+                format: int32
+              message:
+                type: string
+  '/pets/{id}':
+    get:
+      summary: Get a pet by id
+      description: >-
+        Returns a user based on a single ID, if the user does not have access to
+        the pet
+      operationId: find pet by id
+      parameters:
+        - name: Authorization
+          in: header
+          description: OAUTH2 (IAM) or JWT token
+          required: true
+          type: string
+          format: OAUTH2 (IAM) or JWT token
+        - name: id
+          in: path
+          description: ID of pet to fetch
+          required: true
+          type: integer
+          format: int64
+          x-example: 1
+      responses:
+        '200':
+          description: pet response
+          schema:
+            type: object
+            description: Pet description
+            properties:
+              id:
+                description: Id of pet
+                type: integer
+              name:
+                description: Name of pet
+                type: string
+                example: Foo
+              type:
+                description: Type of pet
+                type: string
+                example: cat
+              gender:
+                description: Gender of pet
+                enum:
+                  - male
+                  - female
+          examples:
+            application/json:
+              id: 1
+              name: Foo
+              type: cat
+              gender: female
+        '403':
+          description: Forbidden
+          schema:
+            required:
+              - code
+              - message
+            type: object
+            properties:
+              code:
+                type: integer
+                format: int32
+                description: Status code
+              message:
+                type: string
+                description: Status message
+        default:
+          description: unexpected error
+          schema:
+            required:
+              - code
+              - message
+            type: object
+            properties:
+              code:
+                type: integer
+                format: int32
+              message:
+                type: string
+    delete:
+      summary: Delete a pet
+      description: Deletes a single pet based on the ID supplied
+      operationId: deletePet
+      security:
+        - oauth:
+            - petstore.write
+      parameters:
+        - name: Authorization
+          in: header
+          description: OAUTH2 (IAM) or JWT token
+          required: true
+          type: string
+          format: OAUTH2 (IAM) or JWT token
+        - name: id
+          in: path
+          description: ID of pet to delete
+          required: true
+          type: integer
+          format: int64
+          x-example: 1
+      responses:
+        '204':
+          description: Pet deleted.
+        '403':
+          description: Forbidden
+          schema:
+            required:
+              - code
+              - message
+            type: object
+            properties:
+              code:
+                type: integer
+                format: int32
+                description: Status code
+              message:
+                type: string
+                description: Status message
+        default:
+          description: unexpected error
+          schema:
+            required:
+              - code
+              - message
+            type: object
+            properties:
+              code:
+                type: integer
+                format: int32
+              message:
+                type: string
+definitions:
+  Pets:
+    type: object
+    description: List of pets
+    properties:
+      data:
+        description: List of pets
+        type: array
+        items:
+          type: object
+          description: Pet description
+          properties:
+            id:
+              description: Id of pet
+              type: integer
+            name:
+              description: Name of pet
+              type: string
+              example: Foo
+            type:
+              description: Type of pet
+              type: string
+              example: cat
+            gender:
+              description: Gender of pet
+              enum:
+                - male
+                - female
+  Pet:
+    type: object
+    description: Pet description
+    properties:
+      id:
+        description: Id of pet
+        type: integer
+      name:
+        description: Name of pet
+        type: string
+        example: Foo
+      type:
+        description: Type of pet
+        type: string
+        example: cat
+      gender:
+        description: Gender of pet
+        enum:
+          - male
+          - female
+  NewPet:
+    type: object
+    description: Pet description
+    required:
+      - name
+    properties:
+      name:
+        description: Name of pet
+        type: string
+        example: Foo
+      type:
+        description: Type of pet
+        type: string
+        example: cat
+      gender:
+        description: Gender of pet
+        enum:
+          - male
+          - female
+  Error:
+    required:
+      - code
+      - message
+    type: object
+    properties:
+      code:
+        type: integer
+        format: int32
+      message:
+        type: string
+  Error403:
+    required:
+      - code
+      - message
+    type: object
+    properties:
+      code:
+        type: integer
+        format: int32
+        description: Status code
+      message:
+        type: string
+        description: Status message

--- a/lib/nodejs/swagger/__tests__/_petstore.yaml
+++ b/lib/nodejs/swagger/__tests__/_petstore.yaml
@@ -1,0 +1,249 @@
+swagger: "2.0"
+info:
+  version: 2.0.0
+  title: Swagger Petstore
+  description: A sample API that uses a petstore as an example to demonstrate features in the swagger-2.0 specification
+  termsOfService: http://swagger.io/terms/
+  contact:
+    name: Swagger API Team
+    email: foo@example.com
+    url: https://tech.zalando.com
+  license:
+    name: MIT
+    url: http://github.com/gruntjs/grunt/blob/master/LICENSE-MIT
+securityDefinitions:
+  oauth:
+    type: oauth2
+    tokenUrl: https://auth.example.com/oauth2/token
+    flow: password
+    scopes:
+      petstore.read: Access to read petstore
+      petstore.write: Access to write to petstore
+security:
+  - oauth: [petstore.read]
+host: petstore.swagger.io
+basePath: /api
+schemes:
+  - http
+consumes:
+  - application/json
+produces:
+  - application/json
+parameters:
+  Authorization:
+    name: Authorization
+    in: header
+    description: OAUTH2 (IAM) or JWT token
+    required: true
+    type: string
+    format: OAUTH2 (IAM) or JWT token
+paths:
+  /pets:
+    get:
+      summary: Get pets
+      description: |
+        Returns all pets from the system that the user has access to.
+      operationId: findPets
+      parameters:
+        - $ref: "#/parameters/Authorization"
+        - name: limit
+          in: query
+          description: Maximum number of results to return
+          required: false
+          type: integer
+          format: int32
+          x-example: 10
+      responses:
+        "200":
+          description: Pet response.
+          schema:
+            $ref: '#/definitions/Pets'
+          examples:
+            'application/json':
+              data:
+                - id: 1
+                  name: 'Foo'
+                  type: 'cat'
+                  gender: 'female'
+                - id: 2
+                  name: 'Bar'
+                  type: 'dog'
+                  gender: 'male'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/Error403'
+        default:
+          description: unexpected error
+          schema:
+            $ref: '#/definitions/Error'
+    post:
+      summary: Create a pet
+      description: Creates a new pet in the store.  Duplicates are allowed
+      operationId: addPet
+      security:
+        - oauth: [petstore.write]
+      parameters:
+        - $ref: "#/parameters/Authorization"
+        - name: pet
+          in: body
+          description: Pet to add to the store
+          required: true
+          schema:
+            $ref: '#/definitions/NewPet'
+          x-examples:
+            default:
+                name: 'Foo'
+                type: 'cat'
+                gender: 'female'
+      responses:
+        "201":
+          description: pet response
+          schema:
+            $ref: '#/definitions/Pet'
+          examples:
+            'application/json':
+              id: 1
+              name: 'Foo'
+              type: 'cat'
+              gender: 'female'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/Error403'
+        default:
+          description: unexpected error
+          schema:
+            $ref: '#/definitions/Error'
+  /pets/{id}:
+    get:
+      summary: Get a pet by id
+      description: Returns a user based on a single ID, if the user does not have access to the pet
+      operationId: find pet by id
+      parameters:
+        - $ref: "#/parameters/Authorization"
+        - name: id
+          in: path
+          description: ID of pet to fetch
+          required: true
+          type: integer
+          format: int64
+          x-example: 1
+      responses:
+        "200":
+          description: pet response
+          schema:
+            $ref: '#/definitions/Pet'
+          examples:
+            'application/json':
+              id: 1
+              name: 'Foo'
+              type: 'cat'
+              gender: 'female'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/Error403'
+        default:
+          description: unexpected error
+          schema:
+            $ref: '#/definitions/Error'
+    delete:
+      summary: Delete a pet
+      description: Deletes a single pet based on the ID supplied
+      operationId: deletePet
+      security:
+        - oauth: [petstore.write]
+      parameters:
+        - $ref: "#/parameters/Authorization"
+        - name: id
+          in: path
+          description: ID of pet to delete
+          required: true
+          type: integer
+          format: int64
+          x-example: 1
+      responses:
+        "204":
+          description: Pet deleted.
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/Error403'
+        default:
+          description: unexpected error
+          schema:
+            $ref: '#/definitions/Error'
+definitions:
+  Pets:
+    type: 'object'
+    description: 'List of pets'
+    properties:
+      data:
+        description: 'List of pets'
+        type: 'array'
+        items:
+          $ref: "#/definitions/Pet"
+  Pet:
+    type: 'object'
+    description: 'Pet description'
+    properties:
+      id:
+        description: 'Id of pet'
+        type: 'integer'
+      name:
+        description: 'Name of pet'
+        type: 'string'
+        example: 'Foo'
+      type:
+        description: 'Type of pet'
+        type: 'string'
+        example: 'cat'
+      gender:
+        description: 'Gender of pet'
+        enum:
+          - male
+          - female
+  NewPet:
+    type: 'object'
+    description: 'Pet description'
+    required:
+      - name
+    properties:
+      name:
+        description: 'Name of pet'
+        type: 'string'
+        example: 'Foo'
+      type:
+        description: 'Type of pet'
+        type: 'string'
+        example: 'cat'
+      gender:
+        description: 'Gender of pet'
+        enum:
+          - male
+          - female
+  Error:
+    required:
+      - code
+      - message
+    type: 'object'
+    properties:
+      code:
+        type: integer
+        format: int32
+      message:
+        type: string
+  Error403:
+    required:
+      - code
+      - message
+    type: 'object'
+    properties:
+      code:
+        type: integer
+        format: int32
+        description: 'Status code'
+      message:
+        type: string
+        description: 'Status message'

--- a/lib/nodejs/swagger/__tests__/swagger-unmocked.test.js
+++ b/lib/nodejs/swagger/__tests__/swagger-unmocked.test.js
@@ -1,0 +1,34 @@
+'use strict';
+
+const fs = require('fs');
+
+describe('swager.Swagger.parser', () => {
+  const specFile = 'lib/nodejs/swagger/__tests__/_petstore.yaml';
+  const expectedSpec = 'lib/nodejs/swagger/__tests__/_petstore-parsed.yaml';
+
+  const Swagger = require('../swagger');
+  const decorators = require('../decorators');
+  const swagger = new Swagger(specFile);
+
+  it('should generate xml schema', () => {
+    swagger
+      .validate()
+      .then(swagger =>  swagger.decorate(decorators.docExclude))
+      .then(swagger =>  swagger.decorate(decorators.host))
+      .then(swagger => {
+        const readableStream = fs.createReadStream(expectedSpec);
+        let data = '';
+
+        readableStream
+          .on('readable', () => {
+            let chunk;
+            while ((chunk = readableStream.read()) !== null) {
+              data += chunk;
+            }
+          })
+          .on('end', () => {
+            expect(data).toEqual(swagger.swaggerYaml);
+          });
+      });
+  });
+});

--- a/lib/nodejs/swagger/decorators/docExclude/filters/__tests__/operations.test.js
+++ b/lib/nodejs/swagger/decorators/docExclude/filters/__tests__/operations.test.js
@@ -7,7 +7,7 @@ const dummySwagger = {
     '/pets': {
       'get': {
         'x-doc':{
-          'exclude': true
+          'excluded': true
         }
       },
       'post':{

--- a/lib/nodejs/swagger/decorators/docExclude/filters/__tests__/parameters.test.js
+++ b/lib/nodejs/swagger/decorators/docExclude/filters/__tests__/parameters.test.js
@@ -10,7 +10,7 @@ const dummySwagger = {
     'bar':{
       'name': 'bar',
       'x-doc': {
-        'exclude': true
+        'excluded': true
       }
     }
   },
@@ -24,7 +24,7 @@ const dummySwagger = {
           {
             name: 'param2',
             'x-doc':{
-              'exclude': true
+              'excluded': true
             }
           }
         ]

--- a/lib/nodejs/swagger/decorators/docExclude/filters/__tests__/paths.test.js
+++ b/lib/nodejs/swagger/decorators/docExclude/filters/__tests__/paths.test.js
@@ -10,7 +10,7 @@ const dummySwagger = {
     },
     '/pets/id':{
       'x-doc': {
-        'exclude': true
+        'excluded': true
       }
     }
   }

--- a/lib/nodejs/swagger/decorators/docExclude/filters/__tests__/security.test.js
+++ b/lib/nodejs/swagger/decorators/docExclude/filters/__tests__/security.test.js
@@ -9,12 +9,12 @@ const dummySwagger = {
     },
     'internalAuth':{
       'x-doc': {
-        'exclude': true
+        'excluded': true
       }
     },
     'foo': {
       'x-doc': {
-        'exclude': true
+        'excluded': true
       }
     }
   },

--- a/lib/nodejs/swagger/decorators/docExclude/utils.js
+++ b/lib/nodejs/swagger/decorators/docExclude/utils.js
@@ -4,7 +4,7 @@
  * Key for exclude flag.
  */
 const docKey = 'x-doc';
-const excludeKey = 'exclude';
+const excludeKey = 'excluded';
 
 /**
  * Function to decide what objects to exclude from the schema.

--- a/lib/nodejs/swagger/swagger.js
+++ b/lib/nodejs/swagger/swagger.js
@@ -64,7 +64,12 @@ class Swagger{
    * Returns yamlSchema string.
    */
   get swaggerYaml (){
-    return jsYaml.safeDump(this.swaggerObject);
+    // Stringify will flat the swaggerObject and resolve all the references
+    // Passing the swagger object directly to yaml parser is creating &ref_0 in the generated YAML
+    // FIXME: Check what is wrong with swaggerObject
+    const jsonString = this.swaggerJson;
+    const cleanObject = JSON.parse(jsonString);
+    return jsYaml.safeDump(cleanObject);
   }
 
 


### PR DESCRIPTION
When converting swaggerObject returned by [SwaggerParser.validate()](https://github.com/BigstickCarpet/swagger-parser/blob/master/docs/swagger-parser.md#validateapi-options-callback) to yaml.

The converted YAML has some `&ref_`.


