### PR TITLE
Add E2E tests for major scenarios.

### DIFF
--- a/nightwatch.json
+++ b/nightwatch.json
@@ -24,6 +24,39 @@
             "path": "/get-started.html",
             "id": "Quick-Start",
             "element": "h2"
+          },
+          "highlightToc": {
+            "path": "/usage-and-configuration/swagger/swagger-to-html.html",
+            "href": "#Demo",
+            "tocCurrentClass": "doc-sidebar-list__toc-item--current",
+            "sidebarCurrentRegex": "doc-sidebar-list__item--current"
+          },
+          "generateToc": {
+            "path": "/usage-and-configuration/writing.html",
+            "tocItemSelector": ".doc-sidebar-list__toc-item"
+          },
+          "searchInputVisible": {
+            "path": "/get-started.html",
+            "searchInputSelector": ".doc-sidebar__search-form input.doc-search-form__input"
+          },
+          "searchResultsDisplayed":{
+            "path": "/get-started.html",
+            "searchInputSelector": ".doc-sidebar__search-form input.doc-search-form__input",
+            "searchResultsSelector": ".doc-search-results",
+            "searchTitleQuerySelector": ".doc-search-results__title__query",
+            "searchQuery": "hexo"
+          },
+          "searchResultItems":{
+            "path": "/get-started.html",
+            "searchInputSelector": ".doc-sidebar__search-form input.doc-search-form__input",
+            "searchResultsSelector": ".doc-search-results",
+            "searchTitleQuerySelector": ".doc-search-results__title__query",
+            "searchResultItemSelector": ".doc-search-results__list__item",
+            "searchItemTitleSelector": ".doc-search-results__list__link",
+            "searchItemScoreSelector": ".doc-search-results__list__score",
+            "searchItemSummarySelector": ".doc-search-results__list__item > p",
+            "searchItemSummaryHighlightSelector": ".doc-search-results__list__item .doc-highlight",
+            "searchQuery": "hexo"
           }
         }
       }

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "lint": "eslint tests --ext .js"
   },
   "hexo": {
-    "version": "3.3.9"
+    "version": "3.4.0"
   },
   "dependencies": {
     "hexo": "^3.3.8",

--- a/tests/index.js
+++ b/tests/index.js
@@ -2,18 +2,18 @@
 
 const path = require('path');
 
+const rootTag = '.dc-page';
+
 module.exports = {
   'Open homepage': function (browser) {
     browser
       .url(browser.launchUrl)
-      .waitForElementVisible('body', 1000)
-      .end();
+      .waitForElementVisible(rootTag, 1000);
   },
   'Scroll to Anchor': function (browser) {
     const stepOptions = getStepOptions('scrollToAnchor', browser);
 
     if (!stepOptions) {
-      browser.end();
       return;
     }
 
@@ -21,7 +21,7 @@ module.exports = {
 
     browser
       .url(path.join(browser.launchUrl, stepOptions.path + '#' + stepOptions.id))
-      .waitForElementVisible('body', 1000)
+      .waitForElementVisible(rootTag, 1000)
       .assert.visible(eHeader);
 
     browser
@@ -29,9 +29,174 @@ module.exports = {
         browser.assert.equal(typeof result, 'object');
         browser.assert.equal(result.status, 0);
         browser.assert.equal(result.value.y, 0, 'anchor header should be at the top of the page view');
-      })
-      .end();
+      });
+  },
+  'Current item in TOC and its parents should be highlighted': function (browser){
+    const stepOptions = getStepOptions('highlightToc', browser);
 
+    if (!stepOptions) {
+      return;
+    }
+
+    const ancestorXpath = '/ancestor::li[position()=1]';   // Xpath string to move one ancestor up
+    const anchorXpath = `(//a[contains(@href, '${stepOptions.href}')])`;   // Xpath for finding anchor with href
+
+    // Check if toc is highlighted
+    browser
+      .url(path.join(browser.launchUrl, stepOptions.path +  stepOptions.href))
+      .useXpath()
+      .waitForElementVisible(anchorXpath, 1000)
+      .assert
+      .cssClassPresent(anchorXpath + ancestorXpath, stepOptions.tocCurrentClass, 'Toc is highlighted');   // Check if toc is highlighted
+
+    // Recursively check if all parents of current TOC are highlighted
+    (function checkParent (path){
+      const parent = path + ancestorXpath;
+      browser
+        .element('xpath', parent, function (res){
+          if (!res.status){
+            browser
+              .assert
+              .attributeContains(parent, 'class', stepOptions.sidebarCurrentRegex, 'Parent of TOC is highlighted');
+
+            checkParent(parent);
+          }
+        });
+    })(anchorXpath + ancestorXpath);
+
+  },
+
+  'TOC for a page are generated': function (browser){
+    const stepOptions = getStepOptions('generateToc', browser);
+
+    if (!stepOptions) {
+      return;
+    }
+
+    browser
+      .url(path.join(browser.launchUrl, stepOptions.path))
+      .useCss()
+      .waitForElementVisible(rootTag, 1000);
+
+    browser
+      .elements('css selector', '#page-content h2', (result) => {
+        result.value && result
+          .value
+          .forEach((value, index) => {
+            browser
+              .useCss()
+              .getText(`${stepOptions.tocItemSelector}:nth-of-type(${index + 1})`, function (result){
+                browser
+                  .assert
+                  .equal(result.status, 0);
+
+                browser
+                  .useXpath()
+                  .assert
+                  .containsText(`//div[@id="page-content"] //h2[position()=${index + 1}]`, result.value, 'Title of TOC is same as content of H2');
+              });
+          });
+      });
+  },
+
+  'Search input visible': function (browser){
+    const stepOptions = getStepOptions('searchInputVisible', browser);
+
+    if (!stepOptions) {
+      return;
+    }
+
+    // Search input is present
+    browser
+      .url(path.join(browser.launchUrl, stepOptions.path))
+      .useCss()
+      .waitForElementVisible(rootTag, 1000)
+      .assert
+      .elementPresent(stepOptions.searchInputSelector, 'Search input is present');
+
+    // Search input is visible
+    browser
+      .assert
+      .visible(stepOptions.searchInputSelector, 'Search input is visible');
+  },
+
+  'Search results displayed on search input': function (browser){
+    const stepOptions = getStepOptions('searchResultsDisplayed', browser);
+
+    if (!stepOptions) {
+      return;
+    }
+
+    // Wait for page load
+    browser
+      .url(path.join(browser.launchUrl, stepOptions.path))
+      .useCss()
+      .waitForElementVisible(stepOptions.searchInputSelector, 1000)
+      .setValue(stepOptions.searchInputSelector, stepOptions.searchQuery);
+
+    browser
+      .assert
+      .visible(stepOptions.searchResultsSelector, 'Search results are visible');
+
+    // Search result title is visible and is equal to search query
+    browser
+      .assert
+      .containsText(stepOptions.searchTitleQuerySelector, '"' + stepOptions.searchQuery + '"', 'Search result title is visible and is equal to search query');
+  },
+
+  'Search result items and their details(score, title, summary) are displayed': function (browser){
+    const stepOptions = getStepOptions('searchResultItems', browser);
+
+    if (!stepOptions) {
+      return;
+    }
+
+    browser
+      .url(path.join(browser.launchUrl, stepOptions.path))
+      .useCss()
+      .waitForElementVisible(stepOptions.searchInputSelector, 1000)
+      .setValue(stepOptions.searchInputSelector, stepOptions.searchQuery);
+
+
+    // Search result item is visible
+    browser
+      .assert
+      .visible(stepOptions.searchResultItemSelector, 'Search result item is visible');
+
+    // Search title is visible and contains some text
+    browser
+      .expect
+      .element(stepOptions.searchItemTitleSelector)
+      .text
+      .to
+      .match(new RegExp(stepOptions.searchQuery, 'i'));
+
+    // Search item's score is visible and contains some decimal score
+    browser
+      .expect
+      .element(stepOptions.searchItemScoreSelector)
+      .text
+      .to
+      .match(/score: {0,1}.\d+/);
+
+
+    // Search item summary's highlight contains search query
+    browser
+      .assert
+      .containsText(stepOptions.searchItemSummaryHighlightSelector, stepOptions.searchQuery, 'Search item summary\'s highlight contains search query');
+
+
+
+    // Search items summary is visible and contains some text
+    browser
+      .expect
+      .element(stepOptions.searchItemSummarySelector)
+      .text
+      .to
+      .match(/\w/);
+  },
+  after: function (browser) {
+    browser.end();
   }
 };
 


### PR DESCRIPTION
Add E2E test cases for following scenarios:

* Homepage should be opened.
* When opening a link with hash, page should scroll to the anchor.
* Current item in toc and its parents should be highlighted.
* For a page containing `<h2>`, TOCs are generated.
* Search input is visible.
* Search results are displayed on search input.
* Search result items and their details(score, title, summary) is displayed.
