### PR TITLE
feat(swagger-parser): configurable parser options

### DIFF
--- a/lib/nodejs/__tests__/swagger-store.test.js
+++ b/lib/nodejs/__tests__/swagger-store.test.js
@@ -51,7 +51,11 @@ jest.mock('../swagger', () => ({
 }));
 
 describe('swagger-store', () => {
-  const mockHexo = {};
+  const mockHexo = {
+    config: {
+      theme_config: {}
+    }
+  };
   const swaggerStore = require('../swagger-store')({hexo: mockHexo});
 
   it('should return swagger.helpers', () => {

--- a/lib/nodejs/swagger-store.js
+++ b/lib/nodejs/swagger-store.js
@@ -5,8 +5,16 @@ const crypto = require('crypto');
 const path = require('path');
 const routeMap = Object.create(null);
 const validUrl = require('valid-url');
+const parseTemplateObject = require('@rbarilani/parse-template-object');
 
 module.exports = ({hexo}) => {
+
+  let swaggerParserOptions = Object.assign({}, (hexo.config.theme_config.swagger_parser || {}));
+  swaggerParserOptions = parseTemplateObject(swaggerParserOptions, {
+    imports: {
+      env: process.env
+    }
+  });
 
   const getDigest = (swaggerPath) => {
     return crypto
@@ -14,7 +22,6 @@ module.exports = ({hexo}) => {
       .update(swaggerPath)
       .digest('hex');
   };
-
 
   const prepareRoute = function (specPath){
     const digest = getDigest(specPath);
@@ -60,7 +67,7 @@ module.exports = ({hexo}) => {
 
 
   const getSwagger = function (swaggerPath, dereferenced = false){
-    const swagger = new Swagger(swaggerPath);
+    const swagger = new Swagger(swaggerPath, swaggerParserOptions);
 
     return swagger
       .merge()

--- a/lib/nodejs/swagger/__tests__/swagger.test.js
+++ b/lib/nodejs/swagger/__tests__/swagger.test.js
@@ -44,6 +44,7 @@ describe('swagger.Swagger', () => {
         await expect(swagger.validate())
           .resolves
           .toEqual({
+            options: {},
             swaggerInput: 'path/to/swagger',
             swaggerObject: dereferencedSchema
           });
@@ -58,6 +59,7 @@ describe('swagger.Swagger', () => {
         await expect(swagger.bundle())
           .resolves
           .toEqual({
+            options: {},
             swaggerInput: 'path/to/swagger',
             swaggerObject: referencedSchema
           });
@@ -74,6 +76,7 @@ describe('swagger.Swagger', () => {
         await expect(swagger.decorate(decorator))
           .resolves
           .toEqual({
+            options: {},
             swaggerInput: 'path/to/swagger',
             swaggerObject: {schema: 'DECORATED_SWAGGER'}
           });
@@ -112,6 +115,7 @@ describe('swagger.Swagger', () => {
         await expect(swagger.merge())
           .resolves
           .toEqual({
+            options: {},
             swaggerInput: 'path/to/swagger',
             swaggerObject: mergedSchema
           });

--- a/lib/nodejs/swagger/swagger.js
+++ b/lib/nodejs/swagger/swagger.js
@@ -10,15 +10,16 @@ class Swagger{
 
   /**
    * @param swagger File path for swagger schema or swagger object.
-   *
+   * @params [options={}] swagger parser options
    */
-  constructor (swaggerInput){
+  constructor (swaggerInput, options = {}){
     if (!swaggerInput){
       throw new TypeError('Please provide path for swagger schema or a valid swagger object.');
     } else {
       this.swaggerInput = swaggerInput;
       // Object containing merge of dereferenced swagger and swagger containing references.
       this.swaggerObject = null;
+      this.options = options;
     }
   }
 
@@ -26,7 +27,7 @@ class Swagger{
   /**
    * Validates the swagger schema and gives dereferenced swagger object.
    */
-  validate (){
+  validate () {
     const that = this;
     return this
       ._validate(this.swaggerInput)
@@ -134,7 +135,7 @@ class Swagger{
    * Validates the swagger schema and gives dereferenced swagger object.
    */
   _validate (schema){
-    return SwaggerParser.validate(schema);
+    return SwaggerParser.validate(schema, this.options);
   }
 
 
@@ -142,7 +143,7 @@ class Swagger{
    * Bundles and returns referenced swagger object.
    */
   _bundle (schema){
-    return SwaggerParser.bundle(schema);
+    return SwaggerParser.bundle(schema, this.options);
   }
 
   /**

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "url": "git@github.com:zalando-incubator/hexo-theme-doc.git"
   },
   "dependencies": {
+    "@rbarilani/parse-template-object": "^1.0.0",
     "babel-preset-es2015": "^6.24.1",
     "babel-preset-react": "^6.24.1",
     "babel-register": "^6.26.0",


### PR DESCRIPTION
closes #38 

Add swagger parser options ( used when calling swagger-parser#validate,|bundle|etc).

Example _config.yaml

```yaml
theme_config:
  # see https://github.com/BigstickCarpet/swagger-parser/blob/master/docs/options.md for all available options
  swagger_parser: 
    resolve: 
      http:
        headers: 
          Authorization: 'Bearer <%= env.AUTH_TOKEN %>'
```
When configured in this way, every time a swagger will be "resolved" via http, authorization header will be sent.

`<%= env.AUTH_TOKEN %>` will be replaced with `AUTH_TOKEN` environment variable value.

### TODO:

- [ ] Document this feature.