### PR TITLE
fix(swagger): Parser(unmerge) generating invalid schema.

### DIFF
--- a/lib/nodejs/swagger/__tests__/swagger-mocks.js
+++ b/lib/nodejs/swagger/__tests__/swagger-mocks.js
@@ -15,7 +15,13 @@ const referencedSchema = {
             '$ref': '#/parameters/Auth'
           },
           {
-            'name': 'param1'
+            'name': 'limit',
+            'in': 'query',
+            'description': 'Maximum number of results to return',
+            'required': false,
+            'type': 'integer',
+            'format': 'int32',
+            'x-example': 10
           }
         ],
         'responses': {
@@ -55,7 +61,13 @@ const dereferencedSchema = {
             'name': 'Auth'
           },
           {
-            'name': 'param1'
+            'name': 'limit',
+            'in': 'query',
+            'description': 'Maximum number of results to return',
+            'required': false,
+            'type': 'integer',
+            'format': 'int32',
+            'x-example': 10
           }
         ],
         'responses': {
@@ -101,7 +113,13 @@ const mergedSchema = {
             'name': 'Auth'
           },
           {
-            'name': 'param1'
+            'name': 'limit',
+            'in': 'query',
+            'description': 'Maximum number of results to return',
+            'required': false,
+            'type': 'integer',
+            'format': 'int32',
+            'x-example': 10
           }
         ],
         'responses': {

--- a/lib/nodejs/swagger/swagger.js
+++ b/lib/nodejs/swagger/swagger.js
@@ -122,7 +122,16 @@ class Swagger{
 
     this.swaggerObject = this._traverseToUnmerge(this.swaggerObject, refMatchingFunction, dereferenced);
 
-    return Promise.resolve(this);
+    const that = this;
+
+    return this
+      ._validate(this.swaggerObject)
+      .then(() => {
+        return that;
+      })
+      .catch((e) => {
+        throw new SyntaxError(`Swagger Schema validation failed after un-merging swagger object.\n\nORIGINAL MESSAGE: \n${e.message}`);
+      });
   }
 
 
@@ -154,9 +163,6 @@ class Swagger{
    * @dereferenced: Boolean value, if true returns derefrenced schema else referenced schema is returned.
    */
   _traverseToUnmerge (subject, fn, dereferenced){
-    if (!subject){
-      return {};
-    }
     if (!fn){
       return subject;
     }


### PR DESCRIPTION
Fix issue with `unmerge` in swagger parser generating invalid schema when a value is false.

Closes #90 