### PR TITLE
chore(config): don't symlink hexo-theme-doc

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
+sudo: required
 dist: trusty
+group: deprecated-2017Q4
 
 language: node_js
 

--- a/_config.yml
+++ b/_config.yml
@@ -9,7 +9,7 @@ timezone: UTC
 
 # URL
 ## If your site is put in a subdirectory, set url as 'http://yoursite.com/child' and root as '/child/'
-url: https://zalando-incubator.gtihub.io/
+url: https://zalando-incubator.github.io/
 root: /hexo-theme-doc/
 
 # Writing
@@ -18,7 +18,7 @@ relative_link: false
 # Extensions
 ## Plugins: https://hexo.io/plugins/
 ## Themes: https://hexo.io/themes/
-theme: doc
+theme: ../node_modules/hexo-theme-doc
 
 theme_config:
   favicon: /images/favicon.ico
@@ -34,5 +34,5 @@ marked:
   breaks: false
 
 ignore:
-  - '**/themes/**/*(target|node_modules|packages|lib)'
-  - '**/.+(*)' # ignoring all dirs and files starting with dot (.git, .idea, ...)
+  # development only: ignore sub node_modules when `npm link hexo-theme-doc`
+  - '**/node_modules/**/*node_modules'

--- a/package.json
+++ b/package.json
@@ -5,7 +5,6 @@
   "main": "index.js",
   "license": "MIT",
   "scripts": {
-    "postinstall": "ln -s ../node_modules/hexo-theme-doc ./themes/doc &>/dev/null || true",
     "generate": "hexo clean && hexo generate",
     "deploy": "NODE_DEBUG=gh-pages node deploy.js",
     "serve": "hexo server -s",

--- a/source/get-started.md
+++ b/source/get-started.md
@@ -60,12 +60,6 @@ This section assumes that you are familiar with [Hexo](https://hexo.io) usage. F
 $ npm install hexo-theme-doc --save
 ```
 
-Symlink the package in the `themes` folder. For Linux:
-
-```
-$ ln -s ./themes/doc ./node_modules/hexo-theme-doc
-```
-
 Install the required hexo plugins in your project:
 
 ```
@@ -89,8 +83,13 @@ $ npm install hexo-renderer-ejs hexo-renderer-marked --save
 Update your project `_config.yml`
 
 ```yaml
-theme: doc
-
-ignore:
-  - '**/themes/**/*(node_modules|lib)' # improve performance while `hexo server` is running
+theme: ../node_modules/hexo-theme-doc
 ```
+
+or
+
+```yaml
+theme: doc
+```
+
+If you used GIT to install the theme (not recommended)

--- a/source/index.md
+++ b/source/index.md
@@ -4,7 +4,8 @@ support: false
 ---
 
 # Hexo Doc Theme
->Version 0.1.1
+
+> Version 0.1.2
 
 hexo-theme-doc is a **documentation theme** for [Hexo](https://hexo.io/), the fast and powerful blog framework powered by Node.js. It differs from other Hexo themes by allowing you to present documentation—especially REST API documentation.
 


### PR DESCRIPTION
Don't symlink `node_modules/hexo-theme-doc` as `themes/doc`.
Reference a relative path in the configuration file as `theme`
as suggested here: #112.

##### TODO for #112 

- Update hexo-theme-doc-seed