### PR TITLE
style(navigation): adjust linting issues

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ before_script:
   - "sh -e /etc/init.d/xvfb start" # the starting the virtual X frame buffer: Xvfb process
 
   - git clone --depth=50 --branch=gh-pages-source https://github.com/zalando-incubator/hexo-theme-doc ../hexo-theme-doc-site
-  - cd ../hexo-theme-doc-site && npm install -q && npm link hexo-theme-doc && npm run postinstall && npm run test:setup
+  - cd ../hexo-theme-doc-site && npm install -q && npm link hexo-theme-doc && npm run test:setup
   - cd $TRAVIS_BUILD_DIR
 
 script:

--- a/lib/browser/navigation/components.jsx
+++ b/lib/browser/navigation/components.jsx
@@ -59,7 +59,7 @@ function Sidebar ({items, page, url_for, config, search, uncollapse, tocItems, v
             dc-icon--interactive
             doc-sidebar__vertical-menu__item
             doc-sidebar__vertical-menu__item--primary"
-          onClick={uncollapse}>
+        onClick={uncollapse}>
         </i>
       </div>
       <div className="doc-sidebar-content">


### PR DESCRIPTION

* style(navigation): adjust linting issues
* chore(travis): don't run postinstall task (doesn't exist anymore)

**!!!NOTE!!!** With nodejs version >=9 the `lint` command behaviour detect and fix indentation that causes the same command to fail on version nodejs 7.